### PR TITLE
Correct Exception Handling for ArgoTunnel

### DIFF
--- a/res/ocr.py
+++ b/res/ocr.py
@@ -463,15 +463,17 @@ class ArgoTunnel:
       try:
         with urllib.request.urlopen(f"http://127.0.0.1:{self.metricPort}/metrics") as response:
             hostname = re.search(r'userHostname=\"https://(.+)\"',
-             response.read().decode('utf-8'), re.MULTILINE).group(1)
+             response.read().decode('utf-8'), re.MULTILINE)
             if not hostname:
               time.sleep(1)
               continue
+            hostname = hostname.group(1)
             break
-        if hostname == None:
-            raise RuntimeError("Failed to get user hostname from cloudflared")
       except HTTPError:
         time.sleep(2)
+        
+    if not hostname:
+      raise RuntimeError("Failed to get user hostname from cloudflared")
     
     argotunnelOpenDB[str(self.port)] = hostname
     accessSettingFile("argotunnelDB.json" , argotunnelOpenDB, v=False)


### PR DESCRIPTION
re.search will return None when it is not able to find the pattern and will result in AttributeError when trying to get None.group(1)