### PR TITLE
Fix Jellyfin cell

### DIFF
--- a/OneClickRun.ipynb
+++ b/OneClickRun.ipynb
@@ -195,8 +195,8 @@
         "USE_FREE_TOKEN = True  # @param {type:\"boolean\"}\n",
         "TOKEN = \"\"  # @param {type:\"string\"}\n",
         "LATEST_VERSION = False  # @param {type:\"boolean\"}\n",
-        "CUSTOM_VERSION = \"10.7.6\"  # @param {type:\"string\"} \n",
-        "#@markdown <small>&emsp;Version are available on https://repo.jellyfin.org/archive/linux/stable/</small>\n",
+        "CUSTOM_VERSION = \"10.8.0\"  # @param {type:\"string\"} \n",
+        "#@markdown <small>&emsp;Version are available on https://repo.jellyfin.org/releases/server/linux/versions/stable/combined/</small>\n",
         "REGION = \"SA\" #@param [\"US\", \"EU\", \"AP\", \"AU\", \"SA\", \"JP\", \"IN\"]\n",
         "PORT_FORWARD = \"argotunnel\" #@param [\"ngrok\", \"localhost\", \"argotunnel\"]\n",
         "#@markdown Default <br>&emsp;username : admin\n",
@@ -240,9 +240,9 @@
         "  os.chmod(f\"/usr/bin/{name}\", 0o755)\n",
         "\n",
         "def customVersionSelect():\n",
-        "  allVersionPage = requests.get(\"https://repo.jellyfin.org/archive/linux/stable/\").text\n",
-        "  allVersinoTags = re.findall(r'\">(\\d+\\.\\d+\\.\\d+)', allVersionPage, re.M)\n",
-        "  option_list = sorted(allVersinoTags, reverse=True)\n",
+        "  allVersionPage = requests.get(\"https://repo.jellyfin.org/releases/server/linux/versions/stable/combined/\").text\n",
+        "  allVersionTags = re.findall(r'\">(\\d+\\.\\d+\\.\\d+)', allVersionPage, re.M)\n",
+        "  option_list = sorted(allVersionTags, reverse=True)\n",
         "  dropdown = Select(description=\"Choose one:\", options=option_list)\n",
         "  dropdown.observe(main, names='value')\n",
         "  display(dropdown)\n",
@@ -252,7 +252,7 @@
         "  if not findProcess(\"jellyfin\", \"--ffmpeg\"):\n",
         "    CM = r\"tools/jellyfin/jellyfin/jellyfin --service \" \\\n",
         "    f\"-C tools/jellyfin -d {CWD}/tools/jellyfin\"\n",
-        "    Popen(CM.split())\n",
+        "    Popen(CM.split(), shell=True)\n",
         "\n",
         "\n",
         "  # START_SERVER\n",
@@ -268,12 +268,12 @@
         "  if LATEST_VERSION:\n",
         "    serverUrl = \"https://repo.jellyfin.org/releases/server/linux/stable/combined/\"\n",
         "  elif CUSTOM_VERSION:\n",
-        "    serverUrl = f\"https://repo.jellyfin.org/archive/linux/stable/{CUSTOM_VERSION}/combined/\"\n",
+        "    serverUrl = f\"https://repo.jellyfin.org/releases/server/linux/versions/stable/combined/{CUSTOM_VERSION}/\"\n",
         "  else:\n",
-        "    serverUrl = f\"https://repo.jellyfin.org/archive/linux/stable/{version.new}/combined/\"\n",
+        "    serverUrl = f\"https://repo.jellyfin.org/releases/server/linux/versions/stable/combined/{version.new}/\"\n",
         "\n",
         "  server = requests.get(serverUrl).text\n",
-        "  server_file = re.search(r'f=\\\"(.+)\\\">jellyfin_(.+)\\.tar\\.gz<',\n",
+        "  server_file = re.search(r'f=\\\"(.+)\\\">jellyfin_(.+)_([^-]+)\\.tar\\.gz<',\n",
         "                              server, re.MULTILINE)\n",
         "  server_file_url = server_file.group(1)\n",
         "  versionTag = server_file.group(2)\n",
@@ -2718,22 +2718,10 @@
       ],
       "metadata": {
         "cellView": "form",
-        "id": "NLXcfX-ZKmhG",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "outputId": "98fe384e-2d98-4e2f-f078-b271bc782376"
+        "id": "NLXcfX-ZKmhG"
       },
       "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Requirements installed successfully.\n"
-          ]
-        }
-      ]
+      "outputs": []
     },
     {
       "cell_type": "code",


### PR DESCRIPTION
Fixes #28. I changed the Jellyfin archive link to https://repo.jellyfin.org/releases/server/linux/versions/stable/combined/. Only versions 10.8.0+ work because versions below 10.8.0 are not available to download [here](https://repo.jellyfin.org/archive/server/linux/stable/). If you try to download anything at that link, you get a 404 Not Found error.